### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,19 +12,19 @@ export const metadata: Metadata = {
   icons: {
     icon: [
       {
-        url: '/icon-light-32x32.png',
+        url: '/bgauto/icon-light-32x32.png',
         media: '(prefers-color-scheme: light)',
       },
       {
-        url: '/icon-dark-32x32.png',
+        url: '/bgauto/icon-dark-32x32.png',
         media: '(prefers-color-scheme: dark)',
       },
       {
-        url: '/icon.svg',
+        url: '/bgauto/icon.svg',
         type: 'image/svg+xml',
       },
     ],
-    apple: '/apple-icon.png',
+    apple: '/bgauto/apple-icon.png',
   },
 }
 

--- a/components/about.tsx
+++ b/components/about.tsx
@@ -39,7 +39,7 @@ export function About() {
           <div className="relative">
             <div className="relative overflow-hidden rounded-lg border border-border">
               <Image
-                src="/images/team.png"
+                src="/bgauto/images/team.png"
                 alt="Команда BG AUTO"
                 width={800}
                 height={600}

--- a/components/cases.tsx
+++ b/components/cases.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button"
 const cases = [
   {
     id: 1,
-    image: "/images/case-1.jpg",
+    image: "/bgauto/images/case-1.jpg",
     title: "Toyota Harrier",
     year: 2021,
     client: "клиентке из Улан-Удэ",
@@ -22,7 +22,7 @@ const cases = [
   },
   {
     id: 2,
-    image: "/images/case-2.jpg",
+    image: "/bgauto/images/case-2.jpg",
     title: "Toyota RAV4",
     year: 2020,
     client: "клиенту Алексею из Улан-Удэ",
@@ -36,7 +36,7 @@ const cases = [
   },
   {
     id: 3,
-    image: "/images/case-3.jpg",
+    image: "/bgauto/images/case-3.jpg",
     title: "Lexus RX 350",
     year: 2022,
     client: "клиенту из Читы",
@@ -50,7 +50,7 @@ const cases = [
   },
   {
     id: 4,
-    image: "/images/case-4.jpg",
+    image: "/bgauto/images/case-4.jpg",
     title: "Honda CR-V",
     year: 2021,
     client: "клиенту из Иркутска",
@@ -64,7 +64,7 @@ const cases = [
   },
   {
     id: 5,
-    image: "/images/case-5.jpg",
+    image: "/bgauto/images/case-5.jpg",
     title: "Mazda CX-5",
     year: 2022,
     client: "клиентке Анне из Читы",
@@ -78,7 +78,7 @@ const cases = [
   },
   {
     id: 6,
-    image: "/images/case-6.jpg",
+    image: "/bgauto/images/case-6.jpg",
     title: "Toyota Camry",
     year: 2021,
     client: "клиенту из Улан-Удэ",

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -9,7 +9,7 @@ export function Footer() {
           {/* Logo - fixed size, no shrinking */}
           <Link href="/" className="flex-shrink-0">
             <Image
-              src="/images/logo_footer.png"
+              src="/bgauto/images/logo_footer.png"
               alt="BG AUTO"
               width={100}
               height={22}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -26,7 +26,7 @@ export function Header() {
           {/* Logo - fixed size, no shrinking */}
           <Link href="/" className="flex-shrink-0">
             <Image
-              src="/images/1-2.png"
+              src="/bgauto/images/1-2.png"
               alt="BG AUTO"
               width={140}
               height={50}

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -8,7 +8,7 @@ export function Hero() {
       {/* Background Image */}
       <div className="absolute inset-0 z-0">
         <Image
-          src="/images/hero-car.jpg"
+          src="/bgauto/images/hero-car.jpg"
           alt="Premium Car"
           fill
           className="object-cover object-center"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  basePath: '/bgauto',
+  assetPrefix: '/bgauto',
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary

Fixed website deployment styling and image paths for GitHub Actions by adding base path configuration. Updated all image and icon paths to use `/bgauto` prefix and configured Next.js with `basePath` and `assetPrefix` to properly serve assets when deployed to GitHub Pages.

**Changes:**
- Added `basePath: '/bgauto'` and `assetPrefix: '/bgauto'` to `next.config.mjs`
- Updated all image paths in components (`header`, `hero`, `about`, `cases`, `footer`) to include `/bgauto` prefix
- Updated favicon and apple icon paths in `app/layout.tsx` metadata 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/f42a4f8e-077b-44ec-9120-6d5985c8d55e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/agents"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?theme=light&v=11" height="28"></picture></a> 